### PR TITLE
Reveal _jumping_ when outside Viewport

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,6 +93,10 @@ export function activate(context: vscode.ExtensionContext) {
         editor.setDecorations(decorationTypeOffset1, []);
 
         vscode.window.activeTextEditor.selection = new vscode.Selection(position.line, position.character, position.line, position.character);
+
+        let reviewType: vscode.TextEditorRevealType = vscode.TextEditorRevealType.Default;
+        vscode.window.activeTextEditor.revealRange(vscode.window.activeTextEditor.selection, reviewType);
+
         isJumpyMode = false;
         vscode.commands.executeCommand('setContext', 'jumpy.isJumpyMode', false);
     });


### PR DESCRIPTION
Hi @wmaurer ,

This PR closes #11 .

I used the _less intrusive_ reveal option (`vscode.TextEditorRevealType.Default`) which will make the jumping to _be revealed with as little scrolling as possible_. It will have no effect if the jumping is already visible in the Viewport.